### PR TITLE
Add workaround for iOS/React click event bug.

### DIFF
--- a/lib/typeahead.js
+++ b/lib/typeahead.js
@@ -3,6 +3,8 @@ var React = require('react');
 var cloneWithProps = require('react/lib/cloneWithProps');
 var filter = require('lodash.filter');
 
+React.initializeTouchEvents(true);
+
 var keyboard = {
   space: 32,
   enter: 13,
@@ -32,7 +34,7 @@ var classBase = React.createClass({
       listOpen: false
     };
   },
-  componentWillReceiveProps:function(nextProps) {
+  componentWillReceiveProps:function (nextProps) {
     if (nextProps.list && nextProps.manualMode === true) {
       this.setState({
         list: nextProps.list,
@@ -234,6 +236,11 @@ var classBase = React.createClass({
               props.ref = i;
               props.query = this.state.selectedOptionIndex !== false ? this.state.oldVal : this.state.val;
               props.onMouseDown = this.onClickOption.bind(this, i);
+
+              // This is a workaround for a long-standing iOS/React issue with click events.
+              // See https://github.com/facebook/react/issues/134 for more information.
+              props.onTouchStart = this.onClickOption.bind(this, i);
+              
               props.role = 'button';
               props.selected = i === this.state.selectedOptionIndex;
               props.tabIndex = -1;

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -3,6 +3,8 @@ var React = require('react');
 var cloneWithProps = require('react/lib/cloneWithProps');
 var filter = require('lodash.filter');
 
+React.initializeTouchEvents(true);
+
 var keyboard = {
   space: 32,
   enter: 13,
@@ -234,6 +236,11 @@ var classBase = React.createClass({
               props.ref = i;
               props.query = this.state.selectedOptionIndex !== false ? this.state.oldVal : this.state.val;
               props.onMouseDown = this.onClickOption.bind(this, i);
+
+              // This is a workaround for a long-standing iOS/React issue with click events.
+              // See https://github.com/facebook/react/issues/134 for more information.
+              props.onTouchStart = this.onClickOption.bind(this, i);
+
               props.role = 'button';
               props.selected = i === this.state.selectedOptionIndex;
               props.tabIndex = -1;


### PR DESCRIPTION
As discussed with @kenwheeler this is probably the best current workaround for what seems to be a long-standing iOS/React bug/quirk.

See more:
http://stackoverflow.com/questions/5421659/html-label-command-doesnt-work-in-iphone-browser/6472181#6472181
https://github.com/facebook/react/issues/134
https://github.com/facebook/react/issues/1169