### PR TITLE
Removes react peer dependency, changes devDependency to 0.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   },
   "author": "",
   "license": "MIT",
-  "peerDependencies": {
-    "react": ">=0.12.0 <0.14.0"
-  },
   "devDependencies": {
     "babel-core": "^4.7.16",
     "babel-eslint": "^2.0.2",
@@ -32,7 +29,7 @@
     "karma-webpack": "^1.5.0",
     "lodash": "^3.6.0",
     "mocha": "^2.2.1",
-    "react": ">=0.12.0 <0.14.0",
+    "react": "^0.13.3",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "webpack": "^1.5.3",


### PR DESCRIPTION
There's something really wonky about peerDependencies that can cause some weird react conflicts when the amount of packages being used grows. Removing peerDependencies for react should help fix that.