### PR TITLE
Mobile scroll capability

### DIFF
--- a/lib/typeahead.js
+++ b/lib/typeahead.js
@@ -31,7 +31,8 @@ var classBase = React.createClass({
       oldVal: '',
       selectedOptionIndex: false,
       list: [],
-      listOpen: false
+      listOpen: false,
+      touchScroll: false
     };
   },
   componentWillReceiveProps:function (nextProps) {
@@ -53,6 +54,7 @@ var classBase = React.createClass({
       list: [],
       listOpen: false,
       selectedOptionIndex: false,
+      touchScroll: false,
       val:val
     };
 
@@ -207,6 +209,21 @@ var classBase = React.createClass({
       this.props.onSelectOption(option, index);
     }
   },
+
+  onTouchStart:function (index) {
+    this.setState({ touchScroll: false });
+  },
+
+  onTouchEnd:function (index) {
+    if (!this.state.touchScroll) {
+      this.onClickOption(index);
+    }
+  },
+
+  onTouchMove:function (index) {
+    this.setState({ touchScroll: true });
+  },
+
   render:function () {
     return (
       React.createElement("div", {style: this.props.mainStyle}, 
@@ -220,7 +237,7 @@ var classBase = React.createClass({
           }), 
         
         this.state.listOpen ?
-          React.createElement("div", {className: this.props.listClassName || 'typeahead-list', style: this.props.listStyle}, 
+          React.createElement("div", {className: this.props.listClassName || 'typeahead-list', style: this.props.listStyle, onScroll: this.onScroll}, 
             this.state.list.map(function(item, i)  {
               var props = {
                 children: {}
@@ -239,8 +256,11 @@ var classBase = React.createClass({
 
               // This is a workaround for a long-standing iOS/React issue with click events.
               // See https://github.com/facebook/react/issues/134 for more information.
-              props.onTouchStart = this.onClickOption.bind(this, i);
-              
+              // props.onTouchStart = this.onClickOption.bind(this, i);
+              props.onTouchStart = this.onTouchStart.bind(this, i);
+              props.onTouchEnd = this.onTouchEnd.bind(this, i);
+              props.onTouchMove = this.onTouchMove.bind(this, i);
+
               props.role = 'button';
               props.selected = i === this.state.selectedOptionIndex;
               props.tabIndex = -1;

--- a/lib/typeahead.js
+++ b/lib/typeahead.js
@@ -241,7 +241,7 @@ var classBase = React.createClass({
           }), 
         
         this.state.listOpen ?
-          React.createElement("div", {className: this.props.listClassName || 'typeahead-list', style: this.props.listStyle, onScroll: this.onScroll}, 
+          React.createElement("div", {className: this.props.listClassName || 'typeahead-list', style: this.props.listStyle}, 
             this.state.list.map(function(item, i)  {
               var props = {
                 children: {}

--- a/lib/typeahead.js
+++ b/lib/typeahead.js
@@ -54,7 +54,6 @@ var classBase = React.createClass({
       list: [],
       listOpen: false,
       selectedOptionIndex: false,
-      touchScroll: false,
       val:val
     };
 
@@ -210,17 +209,22 @@ var classBase = React.createClass({
     }
   },
 
-  onTouchStart:function (index) {
-    this.setState({ touchScroll: false });
-  },
-
+  // Once the user has let up on a touch, determine whether their touch was part of a scrolling
+  // gesture (via the state variable, 'touchScroll').
+  // If it was indeed a scroll gesture, we'll consider it a no-op and reset the state variable.
+  // We'll only consider the touch a selection in the case that they did not drag at all between
+  // the time of touch start and touch end.
   onTouchEnd:function (index) {
     if (!this.state.touchScroll) {
       this.onClickOption(index);
     }
+
+    this.setState({ touchScroll: false });
   },
 
-  onTouchMove:function (index) {
+  // capture a mouse drag on a typeahead suggestion and consider it as a 'scrolling' gesture.
+  // we'll track this scrolling as a state variable, 'touchScroll'.
+  onTouchMove:function () {
     this.setState({ touchScroll: true });
   },
 
@@ -257,7 +261,6 @@ var classBase = React.createClass({
               // This is a workaround for a long-standing iOS/React issue with click events.
               // See https://github.com/facebook/react/issues/134 for more information.
               // props.onTouchStart = this.onClickOption.bind(this, i);
-              props.onTouchStart = this.onTouchStart.bind(this, i);
               props.onTouchEnd = this.onTouchEnd.bind(this, i);
               props.onTouchMove = this.onTouchMove.bind(this, i);
 

--- a/lib/typeahead.js
+++ b/lib/typeahead.js
@@ -261,7 +261,7 @@ var classBase = React.createClass({
               // This is a workaround for a long-standing iOS/React issue with click events.
               // See https://github.com/facebook/react/issues/134 for more information.
               props.onTouchEnd = this.onTouchEnd.bind(this, i);
-              props.onTouchMove = this.onTouchMove.bind(this, i);
+              props.onTouchMove = this.onTouchMove.bind(this);
 
               props.role = 'button';
               props.selected = i === this.state.selectedOptionIndex;

--- a/lib/typeahead.js
+++ b/lib/typeahead.js
@@ -260,7 +260,6 @@ var classBase = React.createClass({
 
               // This is a workaround for a long-standing iOS/React issue with click events.
               // See https://github.com/facebook/react/issues/134 for more information.
-              // props.onTouchStart = this.onClickOption.bind(this, i);
               props.onTouchEnd = this.onTouchEnd.bind(this, i);
               props.onTouchMove = this.onTouchMove.bind(this, i);
 

--- a/lib/typeahead.js
+++ b/lib/typeahead.js
@@ -214,18 +214,18 @@ var classBase = React.createClass({
   // If it was indeed a scroll gesture, we'll consider it a no-op and reset the state variable.
   // We'll only consider the touch a selection in the case that they did not drag at all between
   // the time of touch start and touch end.
-  onTouchEnd:function (index) {
+  onTouchEnd: function (index) {
     if (!this.state.touchScroll) {
       this.onClickOption(index);
     }
 
-    this.setState({ touchScroll: false });
+    this.setState({touchScroll: false});
   },
 
   // capture a mouse drag on a typeahead suggestion and consider it as a 'scrolling' gesture.
   // we'll track this scrolling as a state variable, 'touchScroll'.
-  onTouchMove:function () {
-    this.setState({ touchScroll: true });
+  onTouchMove: function () {
+    this.setState({touchScroll: true});
   },
 
   render:function () {

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -241,7 +241,7 @@ var classBase = React.createClass({
           })
         }
         {this.state.listOpen ?
-          <div className={this.props.listClassName || 'typeahead-list'} style={this.props.listStyle} onScroll={this.onScroll}>
+          <div className={this.props.listClassName || 'typeahead-list'} style={this.props.listStyle}>
             {this.state.list.map((item, i) => {
               var props = {
                 children: {}

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -261,7 +261,7 @@ var classBase = React.createClass({
               // This is a workaround for a long-standing iOS/React issue with click events.
               // See https://github.com/facebook/react/issues/134 for more information.
               props.onTouchEnd = this.onTouchEnd.bind(this, i);
-              props.onTouchMove = this.onTouchMove.bind(this, i);
+              props.onTouchMove = this.onTouchMove.bind(this);
 
               props.role = 'button';
               props.selected = i === this.state.selectedOptionIndex;

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -214,18 +214,18 @@ var classBase = React.createClass({
   // If it was indeed a scroll gesture, we'll consider it a no-op and reset the state variable.
   // We'll only consider the touch a selection in the case that they did not drag at all between
   // the time of touch start and touch end.
-  onTouchEnd:function (index) {
+  onTouchEnd: function (index) {
     if (!this.state.touchScroll) {
       this.onClickOption(index);
     }
 
-    this.setState({ touchScroll: false });
+    this.setState({touchScroll: false});
   },
 
   // capture a mouse drag on a typeahead suggestion and consider it as a 'scrolling' gesture.
   // we'll track this scrolling as a state variable, 'touchScroll'.
-  onTouchMove:function () {
-    this.setState({ touchScroll: true });
+  onTouchMove: function () {
+    this.setState({touchScroll: true});
   },
 
   render () {

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -54,7 +54,6 @@ var classBase = React.createClass({
       list: [],
       listOpen: false,
       selectedOptionIndex: false,
-      touchScroll: false,
       val
     };
 
@@ -208,10 +207,6 @@ var classBase = React.createClass({
     if (typeof this.props.onSelectOption === 'function') {
       this.props.onSelectOption(option, index);
     }
-  },
-
-  onTouchStart (index) {
-    this.setState({ touchScroll: false });
   },
 
   // Once the user has let up on a touch, determine whether their touch was part of a scrolling

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -260,7 +260,6 @@ var classBase = React.createClass({
 
               // This is a workaround for a long-standing iOS/React issue with click events.
               // See https://github.com/facebook/react/issues/134 for more information.
-              // props.onTouchStart = this.onClickOption.bind(this, i);
               props.onTouchEnd = this.onTouchEnd.bind(this, i);
               props.onTouchMove = this.onTouchMove.bind(this, i);
 


### PR DESCRIPTION
This is an update to the suggestion options to have improved behavior on mobile devices. 

Namely, with these changes, users will be able to scroll through the suggestions via a drag or swipe and then tap on the option they wish to select. 

With the current implementation, the only mobile touch behavior we're accounting for is a tap start. Which is to say, as soon as the user makes contact with the screen on top of a suggestion, we consider it to be a selection, close the suggestions list, and populate the input. With these changes, they'll be able to scroll up and down, browsing the various suggestions, before making a choice.

Tagging: @kenwheeler @vakhtang @alexlande @rgerstenberger 