### PR TITLE
Allow for typeahead input value to be passed down through props.value

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -83,7 +83,7 @@ const App = React.createClass({
         <h3>AJAX Typeahead</h3>
         <AjaxAhead />
         <h3>Value passed down through props</h3>
-        <RadonTypeahead val="Pass down this value please" manualMode />
+        <RadonTypeahead value="Pass down this value please" manualMode />
       </div>
     );
   }

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -82,6 +82,8 @@ const App = React.createClass({
         />
         <h3>AJAX Typeahead</h3>
         <AjaxAhead />
+        <h3>Value passed down through props</h3>
+        <RadonTypeahead val="Pass down this value please" manualMode />
       </div>
     );
   }

--- a/src/components/typeahead.jsx
+++ b/src/components/typeahead.jsx
@@ -44,14 +44,16 @@ export default React.createClass({
     };
   },
   componentWillReceiveProps(nextProps) {
-    if (nextProps.list && nextProps.manualMode === true) {
-      this.setState({
-        list: nextProps.list,
-        listOpen: nextProps.list.length !== 0
-      });
-    }
-    if (nextProps.val && nextProps.manualMode) {
-      this.setState({ val: nextProps.val });
+    if (nextProps.manualMode) {
+      if (nextProps.list) {
+        this.setState({
+          list: nextProps.list,
+          listOpen: nextProps.list.length !== 0
+        });
+      }
+      if (nextProps.val) {
+        this.setState({ val: nextProps.val });
+      }
     }
   },
   hideList() {

--- a/src/components/typeahead.jsx
+++ b/src/components/typeahead.jsx
@@ -23,7 +23,8 @@ export default React.createClass({
     onArrowNavigation: PropTypes.func,
     onChange: PropTypes.func,
     onResetVal: PropTypes.func,
-    onSelectOption: PropTypes.func
+    onSelectOption: PropTypes.func,
+    val: PropTypes.string
   },
   getDefaultProps() {
     return {
@@ -34,7 +35,7 @@ export default React.createClass({
   },
   getInitialState() {
     return {
-      val: "",
+      val: (this.props.manualMode && this.props.val) ? this.props.val : "",
       oldVal: "",
       selectedOptionIndex: false,
       list: [],
@@ -48,6 +49,9 @@ export default React.createClass({
         list: nextProps.list,
         listOpen: nextProps.list.length !== 0
       });
+    }
+    if (nextProps.val && nextProps.manualMode) {
+      this.setState({ val: nextProps.val });
     }
   },
   hideList() {

--- a/src/components/typeahead.jsx
+++ b/src/components/typeahead.jsx
@@ -24,7 +24,7 @@ export default React.createClass({
     onChange: PropTypes.func,
     onResetVal: PropTypes.func,
     onSelectOption: PropTypes.func,
-    val: PropTypes.string
+    value: PropTypes.string
   },
   getDefaultProps() {
     return {
@@ -35,7 +35,7 @@ export default React.createClass({
   },
   getInitialState() {
     return {
-      val: (this.props.manualMode && this.props.val) ? this.props.val : "",
+      val: (this.props.manualMode && this.props.value) ? this.props.value : "",
       oldVal: "",
       selectedOptionIndex: false,
       list: [],
@@ -51,8 +51,8 @@ export default React.createClass({
           listOpen: nextProps.list.length !== 0
         });
       }
-      if (nextProps.val) {
-        this.setState({ val: nextProps.val });
+      if (nextProps.value) {
+        this.setState({ val: nextProps.value });
       }
     }
   },

--- a/test/client/spec/components/typeahead.spec.jsx
+++ b/test/client/spec/components/typeahead.spec.jsx
@@ -26,4 +26,19 @@ describe("components/typeahead", () => {
     expect(list.containsMatchingElement(<div>bar</div>)).to.equal(true);
     expect(list.containsMatchingElement(<div>baz</div>)).to.equal(true);
   });
+
+  it("can render with a value passed down through props when in manual mode", () => {
+    const testVal = "Test Value";
+    const wrapper = shallow(<Typeahead val={testVal} manualMode />);
+    const inputVal = wrapper.find("input").props().value;
+    expect(inputVal).to.equal(testVal);
+  });
+
+  it("renders with an empty value when not in manual mode", () => {
+    const testVal = "Test Value";
+    const wrapper = shallow(<Typeahead val={testVal} />);
+    const inputVal = wrapper.find("input").props().value;
+    expect(inputVal).to.equal("");
+  });
+
 });

--- a/test/client/spec/components/typeahead.spec.jsx
+++ b/test/client/spec/components/typeahead.spec.jsx
@@ -29,20 +29,20 @@ describe("components/typeahead", () => {
 
   it("can render with a value passed down through props when in manual mode", () => {
     const testVal = "Test Value";
-    const wrapper = shallow(<Typeahead val={testVal} manualMode />);
+    const wrapper = shallow(<Typeahead value={testVal} manualMode />);
     const inputVal = wrapper.find("input").props().value;
     expect(inputVal).to.equal(testVal);
   });
 
-  it("in manual mode, value defaults to '' when val prop is not provided", () => {
+  it("in manual mode, value defaults to '' when value prop is not provided", () => {
     const wrapper = shallow(<Typeahead manualMode />);
     const inputVal = wrapper.find("input").props().value;
     expect(inputVal).to.equal("");
   });
 
-  it("initializes with an empty value when not in manual mode", () => {
+  it("when not in manual mode, value defaults to '' even if value prop is provided", () => {
     const testVal = "Test Value";
-    const wrapper = shallow(<Typeahead val={testVal} />);
+    const wrapper = shallow(<Typeahead value={testVal} />);
     const inputVal = wrapper.find("input").props().value;
     expect(inputVal).to.equal("");
   });

--- a/test/client/spec/components/typeahead.spec.jsx
+++ b/test/client/spec/components/typeahead.spec.jsx
@@ -34,7 +34,13 @@ describe("components/typeahead", () => {
     expect(inputVal).to.equal(testVal);
   });
 
-  it("renders with an empty value when not in manual mode", () => {
+  it("in manual mode, value defaults to '' when val prop is not provided", () => {
+    const wrapper = shallow(<Typeahead manualMode />);
+    const inputVal = wrapper.find("input").props().value;
+    expect(inputVal).to.equal("");
+  });
+
+  it("initializes with an empty value when not in manual mode", () => {
     const testVal = "Test Value";
     const wrapper = shallow(<Typeahead val={testVal} />);
     const inputVal = wrapper.find("input").props().value;


### PR DESCRIPTION
Allows for Radon Typeahead module to render with a value passed down from props if `props.value` is provided and if in manual mode. 

This allows one to have more control over the state of the module through parent components.

Closes #12 