### PR TITLE
fix bug blocking empty values being passed down to state.val

### DIFF
--- a/src/components/typeahead.jsx
+++ b/src/components/typeahead.jsx
@@ -51,7 +51,7 @@ export default React.createClass({
           listOpen: nextProps.list.length !== 0
         });
       }
-      if (nextProps.value) {
+      if (nextProps.hasOwnProperty("value")) {
         this.setState({ val: nextProps.value });
       }
     }


### PR DESCRIPTION
This updates the `componentWillReceiveProps` check for new value being passed down from `if(nextProps.value)` to `if(nextProps.hasOwnProperty("value"))` as former blocks empty strings from being passed down to state. 

Follows up on #13 